### PR TITLE
Fixing an issue where the error handler was not called on nonexistent images

### DIFF
--- a/index.js
+++ b/index.js
@@ -103,13 +103,15 @@ PNGImage.readImage = function (filename, fn) {
 	fn = fn || function () {
 	};
 
-	fs.createReadStream(filename).pipe(image).once('parsed', function () {
+	fs.createReadStream(filename).once('error', function(err) {
+		fn(err, undefined);
+	}).pipe(image).once('parsed', function () {
 		image.removeListener('error', fn);
 		fn(undefined, resultImage);
 	}).once('error', function (err) {
 		image.removeListener('parsed', fn);
 		fn(err, resultImage);
-	});
+	}).pipe(image);
 
 	return resultImage;
 };

--- a/test/index.js
+++ b/test/index.js
@@ -339,6 +339,13 @@ describe('Instance', function () {
 			}.bind(this));
 		});
 
+		it('should error on non-existent image', function (done) {
+			PNGImage.readImage(__dirname + '/nonexistent.png', function (err, image) {
+				expect(err).to.not.be.undefined;
+				done();
+			});
+		});
+
 		it('should load an image', function (done) {
 
 			var contents = fs.readFileSync(__dirname + '/test.png');


### PR DESCRIPTION
There was a missing error handler on the fs stream which caused uncatchable errors if the file didn't exist.