### PR TITLE
Remove buffers `noAssert` argument

### DIFF
--- a/lib/png/chunks/tRNS.js
+++ b/lib/png/chunks/tRNS.js
@@ -207,7 +207,7 @@ module.exports = {
 
 			for (i = 0, len = image.length; i < len; i += 8) {
 
-				index = image.readUInt16BE(i, false);
+				index = image.readUInt16BE(i);
 				if (isIndexed) {
 
 					alpha = colors[index].alpha;
@@ -218,8 +218,8 @@ module.exports = {
 				} else { // All other types
 
 					r = index;
-					g = image.readUInt16BE(i + 2, false);
-					b = image.readUInt16BE(i + 4, false);
+					g = image.readUInt16BE(i + 2);
+					b = image.readUInt16BE(i + 4);
 
 					alpha = this.findAlpha(r, g, b);
 

--- a/lib/png/processor/interlace.js
+++ b/lib/png/processor/interlace.js
@@ -119,9 +119,9 @@ Interlace.prototype._adam7 = function (data, width, height, revert) {
 				jump = ((row * width) + col) * 4;
 
 				if (revert) {
-					output.writeUInt32BE(data.readUInt32BE(sequential, true), jump, true);
+					output.writeUInt32BE(data.readUInt32BE(sequential), jump);
 				} else {
-					output.writeUInt32BE(data.readUInt32BE(jump, true), sequential, true);
+					output.writeUInt32BE(data.readUInt32BE(jump), sequential);
 				}
 
 				position += 4;


### PR DESCRIPTION
Support for the `noAssert` argument dropped in the upcoming Node.js
v.10. This removes the argument to make sure everything works as it
should.

Refs: https://github.com/nodejs/node/pull/18395